### PR TITLE
Feature: Issue 1 - Add monitor routing configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Local temp directory
+output.txt
+tmp/
+data/
+database/
+.idea

--- a/config/osc-dm-proxy-srv/config.yaml
+++ b/config/osc-dm-proxy-srv/config.yaml
@@ -17,11 +17,15 @@ routes:
   # REGISTRAR
   #####
 
-  # Example: /api/registrar/carts
-  # Example: /api/registrar/carts/uuid/{uuid}
-  # Example: /api/registrar/carts/uuid/{uuid}/{product_uuid}/{artifact_uuid}
   - source: "/api/registrar/.*"
     target: "http://osc-dm-registrar-srv:8000"
+
+  #####
+  # MONITOR
+  #####
+
+  - source: "/api/monitor/.*"
+    target: "http://osc-dm-monitor-srv:8000"
 
   #####
   # SEARCH
@@ -33,9 +37,6 @@ routes:
   # PRODUCT INSTANCES (requests routed to local data products)
   #####
 
-  # Example: /api/dataproducts/uuid/{uuid}
-  # Example: /api/dataproducts/uuid/{uuid}/artifacts
-  # Example: /api/dataproducts/uuid/{uuid}/artifacts/{artifact_uuid}
   - source: "/api/dataproducts/.*"
     target: "dataproduct_resolver"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,7 +49,6 @@ services:
         networks:
           - localnet
 
-    # Data Mesh Proxy
     osc-dm-proxy-srv:
         image: ${DOCKERHUB_USERNAME}/osc-dm-proxy-srv:latest
         hostname: osc-dm-proxy-srv
@@ -65,7 +64,6 @@ services:
         networks:
         - localnet
 
-    # Data Mesh Registrar
     osc-dm-registrar-srv:
         image: ${DOCKERHUB_USERNAME}/osc-dm-registrar-srv:latest
         hostname: osc-dm-registrar-srv
@@ -81,17 +79,17 @@ services:
         networks:
         - localnet
 
-    # Data Mesh Marketplace (UX)
-    osc-dm-marketplace-ux:
-        image: ${DOCKERHUB_USERNAME}/osc-dm-marketplace-ux:latest
-        hostname: osc-dm-marketplace-ux
-        # container_name: osc-dm-marketplace-ux
+    osc-dm-monitor-srv:
+        image: ${DOCKERHUB_USERNAME}/osc-dm-monitor-srv:latest
+        hostname: osc-dm-monitor-srv
         ports:
         # OUTSIDE:INSIDE
-        # curl http://localhost:${SERVER_PORT}/data
-        - 3000:3000
+        - 22000:8000
         volumes:
-        - ${PROJECT_DIR}/config/osc-dm-marketplace-ux:/app/config
+        - ${PROJECT_DIR}/config/osc-dm-monitor-srv:/app/config
+        - ${PROJECT_DIR}/data/osc-dm-monitor-srv:/app/data
+        environment:
+          OPENAI_API_KEY: ${OPENAI_API_KEY}
         networks:
         - localnet
 
@@ -106,6 +104,19 @@ services:
         - ${PROJECT_DIR}/data/osc-dm-search-srv:/app/data
         environment:
           OPENAI_API_KEY: ${OPENAI_API_KEY}
+        networks:
+        - localnet
+
+    osc-dm-marketplace-ux:
+        image: ${DOCKERHUB_USERNAME}/osc-dm-marketplace-ux:latest
+        hostname: osc-dm-marketplace-ux
+        # container_name: osc-dm-marketplace-ux
+        ports:
+        # OUTSIDE:INSIDE
+        # curl http://localhost:${SERVER_PORT}/data
+        - 3000:3000
+        volumes:
+        - ${PROJECT_DIR}/config/osc-dm-marketplace-ux:/app/config
         networks:
         - localnet
 


### PR DESCRIPTION
Add a route in the proxy configuration to all routing for monitor requests:

  #####
  # MONITOR
  #####

  - source: "/api/monitor/.*"
    target: "http://osc-dm-monitor-srv:8000"